### PR TITLE
Make machinegun work w/ mg-riak as designed

### DIFF
--- a/config/machinegun/config.yaml
+++ b/config/machinegun/config.yaml
@@ -13,7 +13,7 @@ woody_server:
 
 storage:
   type: riak
-  host: riak
+  host: mg-riak
   port: 8087
   pool:
     size: 10

--- a/config/machinegun/config.yaml
+++ b/config/machinegun/config.yaml
@@ -31,8 +31,7 @@ consuela:
     session_ttl: 30s
     session_renewal_interval: 10s
   discovery:
-    tags:
-    - production
+    tags: []
 
 # Consul client settings.
 # Required when distributed machine registry is enabled.

--- a/config/mg-riak/user.yaml
+++ b/config/mg-riak/user.yaml
@@ -1,0 +1,2 @@
+storage_backend = leveldb
+retry_put_coordinator_failure = off

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -31,6 +31,9 @@ releases:
 - name: mg-riak
   <<: *default
   chart: ./services/riak
+  set:
+  - name: config.user
+    file: config/mg-riak/user.yaml
 - name: machinegun
   <<: *default
   set:

--- a/services/riak/templates/configmap.yaml
+++ b/services/riak/templates/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   user.conf: |
     ## Config should be configured in values
-{{ .Values.config.user | indent 4 }}
+    {{ .Values.config.user | nindent 4 }}

--- a/services/riak/templates/configmap.yaml
+++ b/services/riak/templates/configmap.yaml
@@ -5,7 +5,5 @@ metadata:
   name: {{ include "riak.fullname" . }}-user-config
 data:
   user.conf: |
-    ## Config should be configured in values   
-{{- with .Values.config.user }}    
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    ## Config should be configured in values
+{{ .Values.config.user | indent 4 }}

--- a/services/riak/templates/statefulset.yaml
+++ b/services/riak/templates/statefulset.yaml
@@ -17,6 +17,7 @@ spec:
         riak/properties-hash: {{ include "riak.propertiesHash" . }}
       labels:
         app: {{ .Chart.Name }}
+        {{- include "riak.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "riak.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10

--- a/services/riak/values.yaml
+++ b/services/riak/values.yaml
@@ -53,11 +53,10 @@ tolerations: []
 
 affinity: {}
 
-config: 
+config:
   user: {}
 
 storage:
-  storageClassName: hostpath
   accessModes: ["ReadWriteOnce"]
   resources:
      requests:

--- a/services/riak/values.yaml
+++ b/services/riak/values.yaml
@@ -54,7 +54,7 @@ tolerations: []
 affinity: {}
 
 config:
-  user: {}
+  user: ""
 
 storage:
   accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
Моё окружение, на всякий случай:
```
minikube version: v1.9.2
```
```
kubectl version:
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:50:46Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
```
```
$ kubectl describe storageclass
Name:            standard
IsDefaultClass:  Yes
Annotations:     kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"},"labels":{"addonmanager.kubernetes.io/mode":"EnsureExists"},"name":"standard"},"provisioner":"k8s.io/minikube-hostpath"}
,storageclass.kubernetes.io/is-default-class=true
Provisioner:           k8s.io/minikube-hostpath
Parameters:            <none>
AllowVolumeExpansion:  <unset>
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     Immediate
```